### PR TITLE
rethinking Button for accessibility

### DIFF
--- a/client/src/components/_atoms/Button/Button.scss
+++ b/client/src/components/_atoms/Button/Button.scss
@@ -1,5 +1,14 @@
 @import "@style";
 
+$btn-types: (
+    "submit",
+    "dark",
+    "light",
+    "invite",
+    "role-select-left",
+    "role-select-right"
+);
+
 .button {
     all: inherit;
     min-height: $btn-height;
@@ -14,6 +23,13 @@
     text-align: center;
     cursor: pointer;
     border: none;
+    display: inline-block;
+
+    @each $btn-type in $btn-types {
+        &.btn-#{$btn-type} {
+            color: $font-light;
+        }
+    }
 
     &.btn-submit {
         $background-color: $blue-200;
@@ -24,8 +40,17 @@
         }
     }
 
-    &.btn-deny {
+    &.btn-dark {
         $background-color: $blue-500;
+        background-color: $background-color;
+
+        &:hover {
+            background-color: lighten($background-color, 10%);
+        }
+    }
+
+    &.btn-light {
+        $background-color: $blue-200;
         background-color: $background-color;
 
         &:hover {
@@ -42,18 +67,9 @@
         }
     }
 
-    &.btn-default {
-        $background-color: $blue-200;
-
-        &:hover {
-            background-color: lighten($background-color, 10%);
-        }
-    }
-
     &.btn-role-select-left {
         $background-color: $green-400;
         background-color: $background-color;
-        color: $primary-light;
 
         &:hover {
             background-color: $green-300;
@@ -63,7 +79,6 @@
     &.btn-role-select-right {
         $background-color: $orange-500;
         background-color: $background-color;
-        color: $primary-light;
 
         &:hover {
             background-color: $orange-400;

--- a/client/src/components/_atoms/Button/Button.tsx
+++ b/client/src/components/_atoms/Button/Button.tsx
@@ -8,12 +8,12 @@ type ButtonTypes =
 	| "button"
 	| "role-select-left"
 	| "role-select-right";
-/** For adding a new type: 
+/** To add a new type:
  * 1. Add the type in ButtonTypes up above
  * 2. Add the type in Button.scss (list $btn-types)
  * 3. Add the type in buttonClassName in Button.tsx
  * The new className must start with btn-
-*/
+ */
 
 export default function Button({
 	type,

--- a/client/src/components/_atoms/Button/Button.tsx
+++ b/client/src/components/_atoms/Button/Button.tsx
@@ -2,11 +2,18 @@ import "./Button.scss";
 
 type ButtonTypes =
 	| "submit"
-	| "form-deny"
+	| "btn-dark"
+	| "btn-light"
 	| "invite"
 	| "button"
 	| "role-select-left"
 	| "role-select-right";
+/** For adding a new type: 
+ * 1. Add the type in ButtonTypes up above
+ * 2. Add the type in Button.scss (list $btn-types)
+ * 3. Add the type in buttonClassName in Button.tsx
+ * The new className must start with btn-
+*/
 
 export default function Button({
 	type,
@@ -25,28 +32,22 @@ export default function Button({
 	const buttonClassName =
 		type === "submit"
 			? "btn-submit"
-			: type === "form-deny"
-				? "btn-deny"
+			: type === "btn-dark"
+				? "btn-dark"
 				: type === "invite"
 					? "btn-invite"
 					: type === "role-select-left"
 						? "btn-role-select-left"
 						: type === "role-select-right"
 							? "btn-role-select-right"
-							: "btn-default";
+							: "btn-light";
 
 	if (href) {
 		return (
-			<a href={href}>
-				<button
-					type={buttonType}
-					className={`button ${buttonClassName}`}
-					onClick={onClick}
-				>
-					{type === "invite" && !children
-						? "+ Inviter un client à s'inscrire"
-						: children}
-				</button>
+			<a href={href} className={`button ${buttonClassName}`} onClick={onClick}>
+				{type === "invite" && !children
+					? "+ Inviter un client à s'inscrire"
+					: children}
 			</a>
 		);
 	}

--- a/client/src/layouts/WelcomePage/FillerContent/FillerContent.tsx
+++ b/client/src/layouts/WelcomePage/FillerContent/FillerContent.tsx
@@ -18,7 +18,7 @@ function FillerContent() {
 			<article className="welcomepage__filler--article">
 				<h2 className="homepage__title">Envie d’essayer&nbsp;?</h2>
 				<p>Une question&nbsp;? Besoin d'une précision&nbsp;? N'hésitez plus.</p>
-				<Button href="/contact" type="form-deny">
+				<Button href="/contact" type="btn-dark">
 					Contactez-nous
 				</Button>
 			</article>

--- a/client/src/layouts/WelcomePage/HeaderAndMain.scss
+++ b/client/src/layouts/WelcomePage/HeaderAndMain.scss
@@ -13,6 +13,7 @@ $welcomePageHeaderHeight: 10vh;
     padding: 0vh 3vw;
     border-bottom: 2px solid $beige-300;
     background-color: $beige-100;
+    z-index: 10;
 }
 
 .welcomepage__header--logo {
@@ -30,6 +31,7 @@ $welcomePageHeaderHeight: 10vh;
     font-weight: $semiBold;
     font-style: normal;
     letter-spacing: 1px;
+    z-index: 11;
     // This centering method allows all elements to stay clickable without overlays
     left: 50%;
     transform: translateX(-50%);
@@ -38,7 +40,7 @@ $welcomePageHeaderHeight: 10vh;
         color: $primary-dark;
 
         &:hover {
-            color: $hovered-link;
+            color: lighten($primary-dark, 15%);
         }
 
         &:active {

--- a/client/src/pages/DesignSystem/DesignSystem.tsx
+++ b/client/src/pages/DesignSystem/DesignSystem.tsx
@@ -56,27 +56,20 @@ export default function DesignSystem() {
 							<Button type="btn-light" href="/">
 								Link light
 							</Button>
-							<Button type="btn-light">
-								Button light
-							</Button>
+							<Button type="btn-light">Button light</Button>
 						</div>
 						<div>
 							<Button type="btn-dark" href="/">
 								Link dark
 							</Button>
-							<Button type="btn-dark">
-								Button dark
-							</Button>
+							<Button type="btn-dark">Button dark</Button>
 						</div>
 						<div>
 							<Button type="invite" href="/" />
 							<Button type="invite" />
-
 						</div>
 						<div>
-							<Button type="button">
-								Actual button
-							</Button>
+							<Button type="button">Actual button</Button>
 						</div>
 
 						<div>

--- a/client/src/pages/DesignSystem/DesignSystem.tsx
+++ b/client/src/pages/DesignSystem/DesignSystem.tsx
@@ -53,21 +53,29 @@ export default function DesignSystem() {
 					<h2>Buttons</h2>
 					<div>
 						<div>
-							<Button type="submit" href="/">
-								Form Submit
+							<Button type="btn-light" href="/">
+								Link light
+							</Button>
+							<Button type="btn-light">
+								Button light
 							</Button>
 						</div>
 						<div>
-							<Button type="form-deny" href="/">
-								Form Deny
+							<Button type="btn-dark" href="/">
+								Link dark
+							</Button>
+							<Button type="btn-dark">
+								Button dark
 							</Button>
 						</div>
 						<div>
 							<Button type="invite" href="/" />
+							<Button type="invite" />
+
 						</div>
 						<div>
-							<Button type="button" href="/">
-								Button
+							<Button type="button">
+								Actual button
 							</Button>
 						</div>
 
@@ -95,7 +103,7 @@ export default function DesignSystem() {
 					<Form title="Connectez-vous ici">
 						<TextInput type="email" />
 						<TextInput type="password" />
-						<Button type="form-deny" href="">
+						<Button type="btn-dark" href="">
 							Annuler
 						</Button>
 						<Button type="submit" href="">

--- a/client/src/pages/Handling/ErrorPage.scss
+++ b/client/src/pages/Handling/ErrorPage.scss
@@ -18,18 +18,8 @@
             font-size: clamp(1.3rem ,4vw ,2rem );
             text-wrap: balance;
         }
-        
-        a {
-            display: inline-block;
-            background-color: $primary-dark;
-            color: $primary-light;
-            font-weight: $medium;
-            padding: 1.5vh 3vw;
-            border-radius: 5px;
-            letter-spacing: 1px;
-        }
 
-        > * {
+        h1, p {
             margin: 0
         }
     }

--- a/client/src/pages/Handling/ErrorPage.tsx
+++ b/client/src/pages/Handling/ErrorPage.tsx
@@ -27,7 +27,9 @@ export default function ErrorPage() {
 						Une erreur inattendue <br /> s'est produite
 					</p>
 				)}
-				<Button href="/" type="btn-dark">Retour à l'accueil</Button>
+				<Button href="/" type="btn-dark">
+					Retour à l'accueil
+				</Button>
 			</hgroup>
 			<img src={dog404} alt="Chien débranchant une prise" />
 		</main>

--- a/client/src/pages/Handling/ErrorPage.tsx
+++ b/client/src/pages/Handling/ErrorPage.tsx
@@ -1,7 +1,7 @@
 import { useRouteError, isRouteErrorResponse } from "react-router-dom";
-import { Link } from "react-router-dom";
 import dog404 from "@/assets/illustrations/dog404.png";
 import "./ErrorPage.scss";
+import Button from "@/components/_atoms/Button/Button";
 
 export default function ErrorPage() {
 	const error = useRouteError();
@@ -27,7 +27,7 @@ export default function ErrorPage() {
 						Une erreur inattendue <br /> s'est produite
 					</p>
 				)}
-				<Link to="/">Retour à l'accueil</Link>
+				<Button href="/" type="btn-dark">Retour à l'accueil</Button>
 			</hgroup>
 			<img src={dog404} alt="Chien débranchant une prise" />
 		</main>

--- a/client/src/pages/Registration/Registration.tsx
+++ b/client/src/pages/Registration/Registration.tsx
@@ -53,7 +53,7 @@ function Registration() {
 					<TextInput type="telephone" />
 					<input type="hidden" name="role" value={role} />
 
-					<Button type="form-deny" href="/registration">
+					<Button type="btn-dark" href="/registration">
 						Retour
 					</Button>
 


### PR DESCRIPTION
Les formats **default** et **form-deny** sont devenus **light** et **dark** puisqu'au final il s'agissait juste des deux couleurs possibles pour nos boutons.
Quand le bouton est un lien, alors il n'y a plus de bouton autour.