### PR TITLE
add cors policy

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,8 +2,10 @@
 
 # if VITE_NODE_ENV === production,
 # AuthGuard is on
-# Appolo client use nginx location
 VITE_NODE_ENV="dev"
+
+# Server location change to /graphql in staging or prod 
+VITE_API_URL="http://localhost:3200"
 
 ## Server 
 

--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,12 @@
+## Client
+
+# if VITE_NODE_ENV === production,
+# AuthGuard is on
+# Appolo client use nginx location
+VITE_NODE_ENV="dev"
+
+## Server 
+
 DBNAME=YOUR_DBNAME
 DBUSERNAME=YOUR_DBUSERNAME
 DBPASS=YOUR_DB_PASS

--- a/client/src/graphQL/apolloClient.ts
+++ b/client/src/graphQL/apolloClient.ts
@@ -1,11 +1,11 @@
 import { ApolloClient, InMemoryCache } from "@apollo/client";
 
-const isProd = import.meta.env.VITE_NODE_ENV === "production";
+const useCredentials = import.meta.env.VITE_API_URL === "/grahql";
 
 const client = new ApolloClient({
-	uri: isProd ? "/graphql" : "http://localhost:3200",
+	uri: import.meta.env.VITE_API_URL || "http://localhost:3200",
 	cache: new InMemoryCache(),
-	credentials: isProd ? "include" : "omit",
+	credentials: useCredentials ? "include" : "omit",
 });
 
 export default client;

--- a/client/src/graphQL/apolloClient.ts
+++ b/client/src/graphQL/apolloClient.ts
@@ -1,8 +1,11 @@
 import { ApolloClient, InMemoryCache } from "@apollo/client";
 
+const isProd = import.meta.env.VITE_NODE_ENV === "production";
+
 const client = new ApolloClient({
-	uri: "http://localhost:3200/",
+	uri: isProd ? "/graphql" : "http://localhost:3200",
 	cache: new InMemoryCache(),
+	credentials: isProd ? "include" : "omit",
 });
 
 export default client;

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,6 +11,8 @@ services:
       - WDS_SOCKET=127.0.0.1
       - CHOKIDAR_USEPOLLING=true
       - WATCHPACK_POLLING=true
+    env_file:
+      - .env
 
   server:
     image: dolpheus89/prod_server_pawplanner
@@ -19,17 +21,8 @@ services:
       - db
     ports:
       - 3201:3200
-    environment:
-      - DBNAME=${DBNAME}
-      - DBUSERNAME=${DBUSERNAME}
-      - DBPASS=${DBPASS}
-      - SMTP_HOST=${SMTP_HOST}
-      - SMTP_PORT=${SMTP_PORT}
-      - SMTP_USER=${SMTP_USER}
-      - SMTP_PASS=${SMTP_PASS}
-      - NODE_ENV="production"
-      - FRONTEND_URL=${FRONTEND_URL}
-      - JWTSECRETKEY=${JWTSECRETKEY}
+    env_file:
+      - .env
 
   db:
     image: postgres:16
@@ -42,10 +35,6 @@ services:
     ports:
       - 5434:5432
     container_name: pawplanner-db-1
-    environment:
-      - POSTGRES_USER=${DBUSERNAME}
-      - POSTGRES_PASSWORD=${DBPASS}
-      - POSTGRES_DB=${DBNAME}
   adminer:
     image: adminer
     restart: unless-stopped

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -11,6 +11,8 @@ services:
       - WDS_SOCKET=127.0.0.1
       - CHOKIDAR_USEPOLLING=true
       - WATCHPACK_POLLING=true
+    env_file:
+      - .env
 
   server:
     image: dolpheus89/staging_server_pawplanner
@@ -19,17 +21,8 @@ services:
       - db
     ports:
       - 3200:3200
-    environment:
-      - DBNAME=${DBNAME}
-      - DBUSERNAME=${DBUSERNAME}
-      - DBPASS=${DBPASS}
-      - SMTP_HOST=${SMTP_HOST}
-      - SMTP_PORT=${SMTP_PORT}
-      - SMTP_USER=${SMTP_USER}
-      - SMTP_PASS=${SMTP_PASS}
-      - NODE_ENV="production"
-      - FRONTEND_URL=${FRONTEND_URL}
-      - JWTSECRETKEY=${JWTSECRETKEY}
+    env_file:
+      - .env
 
   db:
     image: postgres:16
@@ -42,10 +35,6 @@ services:
     ports:
       - 5433:5432
     container_name: pawplanner-db-1
-    environment:
-      - POSTGRES_USER=${DBUSERNAME}
-      - POSTGRES_PASSWORD=${DBPASS}
-      - POSTGRES_DB=${DBNAME}
   adminer:
     image: adminer
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - WDS_SOCKET=127.0.0.1
       - CHOKIDAR_USEPOLLING=true
       - WATCHPACK_POLLING=true
+    env_file:
+      - .env
 
   server:
     build: ./server
@@ -19,17 +21,8 @@ services:
       - 3200:3200
     volumes:
       - ./server:/server
-    environment:
-      - DBNAME=${DBNAME}
-      - DBUSERNAME=${DBUSERNAME}
-      - DBPASS=${DBPASS}
-      - SMTP_HOST=${SMTP_HOST}
-      - SMTP_PORT=${SMTP_PORT}
-      - SMTP_USER=${SMTP_USER}
-      - SMTP_PASS=${SMTP_PASS}
-      - NODE_ENV=${NODE_ENV}
-      - FRONTEND_URL=${FRONTEND_URL}
-      - JWTSECRETKEY=${JWTSECRETKEY}
+    env_file:
+      - .env
 
   db:
     image: postgres:16
@@ -42,8 +35,6 @@ services:
     ports:
       - 5433:5432
     container_name: pawplanner-db-1
-    environment:
-      - POSTGRES_PASSWORD=${DBPASS}
 
   adminer:
     image: adminer

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,18 +1,47 @@
 events {}
-
 http {
-  include mime.types;
+    include mime.types;
 
-  server {
-    listen 81;
-
-    location /graphql {
-      proxy_pass http://server:3200;
+    map_hash_bucket_size 128;
+    
+    map $http_origin $cors_origin {
+        default "";
+        "~^https?://localhost(:[0-9]+)?$" "$http_origin";
+        "https://staging.pawplanner.052024-jaune-2.wns.wilders.dev" "$http_origin";
+        "https://pawplanner.052024-jaune-2.wns.wilders.dev" "$http_origin";
     }
-
-    location / {
-      root /web-client-build;
-      try_files $uri /index.html;
+    
+    server {
+        listen 80;
+        
+        location /graphql {
+            proxy_pass http://server:3200;
+            
+            # OPTIONS request
+            if ($request_method = 'OPTIONS') {
+                add_header 'Access-Control-Allow-Origin' $cors_origin;
+                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, DELETE, PATCH';
+                add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization';
+                add_header 'Access-Control-Max-Age' 1728000;
+                add_header 'Content-Type' 'text/plain charset=UTF-8';
+                add_header 'Content-Length' 0;
+                return 204;
+            }
+            
+            # Other requests
+            add_header 'Access-Control-Allow-Origin' $cors_origin always;
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, DELETE, PATCH' always;
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization' always;
+            add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
+        }
+        
+        location / {
+            root /web-client-build;
+            try_files $uri /index.html;
+            add_header 'Access-Control-Allow-Origin' $cors_origin always;
+        }
     }
-  }
 }
+
+## https://enable-cors.org/server_nginx.html
+## https://www.apollographql.com/docs/apollo-server/security/cors


### PR DESCRIPTION
# CORS Policy

Nginx bloque par défaut toutes les origines, et Apollo Server fait exactement le contraire.

Donc, mise en place d’une logique CORS qui prend en charge les deux options. Aucun changement visible pour le mode développement, mais staging et production auront un Nginx adapté.

Une amélioration des Docker Compose a aussi été faite pour prendre en compte toutes les variables du `.env`, afin de ne plus avoir à les lister.

