### PR TITLE
Fix : query GetAllEvents

### DIFF
--- a/client/src/graphQL/queries/event.ts
+++ b/client/src/graphQL/queries/event.ts
@@ -2,25 +2,19 @@ import { gql } from "@apollo/client";
 
 export const GET_ALL_EVENTS = gql`
     query GetAllEvents {
-        query GetAllEvents {
-            getAllEvents {
-                id
-                date
-                title
-                description
-                group_max_size
-                location {
-                latitude
-                longitude
-                }
-                price
-                startDate
-                endDate
-                service {
-                    id
-                    title
-                }
+        getAllEvents {
+            id
+            date
+            title
+            description
+            group_max_size
+            location {
+            latitude
+            longitude
             }
+            price
+            startDate
+            endDate
         }
     }
 `;
@@ -40,10 +34,6 @@ export const GET_EVENT_BY_ID = gql`
             }
             group_max_size
             price
-            service {
-                id
-                title
-            }
         }
     }
 `;


### PR DESCRIPTION
Fix de la query GetAllEvents 05/03/2025 :

- Dans client\src\graphQL\queries\event.ts il y avait deux fois query GetAllEvents
- Suppression momentané des services dans les query afin de pouvoir afficher les événements