### PR TITLE
Ajout du PlanningHeader avec condition pour le role owner

### DIFF
--- a/client/src/components/_molecules/PlanningHeader/PlanningHeader.tsx
+++ b/client/src/components/_molecules/PlanningHeader/PlanningHeader.tsx
@@ -1,5 +1,6 @@
 import "./PlanningHeader.scss";
 import Button from "@/components/_atoms/Button/Button";
+import { useUser } from "@/hooks/useUser";
 
 export default function PlanningHeader({
 	title,
@@ -12,11 +13,16 @@ export default function PlanningHeader({
 	buttonLabel?: "invite" | "event";
 	href?: string;
 }) {
+	const { role } = useUser();
+	const isTrainer = role === "trainer";
+
 	return (
 		<>
 			<header className="planningHeader">
 				<h1 className="planningHeader__title">{title}</h1>
-				{button && <Button style={buttonLabel} type="button" href={href} />}
+				{button && isTrainer && buttonLabel && href && (
+					<Button style={buttonLabel} type="button" href={href} />
+				)}
 			</header>
 		</>
 	);

--- a/client/src/pages/Event/EventDetail/EventDetail.tsx
+++ b/client/src/pages/Event/EventDetail/EventDetail.tsx
@@ -100,14 +100,11 @@ function EventDetail() {
 
 	return (
 		<>
-			{user?.role === "trainer" && (
-				<PlanningHeader
-					title="Planning"
-					buttonLabel="event"
-					href="/trainer/planning/new"
-				/>
-			)}
-
+			<PlanningHeader
+				title="Planning"
+				buttonLabel="event"
+				href="/trainer/planning/new"
+			/>
 			<section className="eventDetail__section">
 				<div className="eventDetail__event">
 					<div className="eventDetail__event--card">
@@ -150,8 +147,10 @@ function EventDetail() {
 							className="createEvent__event eventDetail__description eventDetail__margin"
 							label="Description"
 							inputType="textarea"
+							name="description"
 							type="description"
-							placeholder={event.description}
+							value={event.description}
+							onChange={() => ""}
 						/>
 						{/*<label className="createEvent__event eventDetail__event--location eventDetail__margin">
 							Localisation

--- a/client/src/pages/Planning/Planning.tsx
+++ b/client/src/pages/Planning/Planning.tsx
@@ -152,13 +152,11 @@ function Planning() {
 
 	return (
 		<>
-			{user?.role === "trainer" && (
-				<PlanningHeader
-					title={title}
-					buttonLabel="event"
-					href="/trainer/planning/new"
-				/>
-			)}
+			<PlanningHeader
+				title={title}
+				buttonLabel="event"
+				href="/trainer/planning/new"
+			/>
 			<div className="calendar-container">
 				<FullCalendar
 					plugins={[

--- a/client/src/pages/Profile/Profile.tsx
+++ b/client/src/pages/Profile/Profile.tsx
@@ -149,7 +149,7 @@ function Profile() {
 
 	return (
 		<>
-			<PlanningHeader title="Mon profil" button={false} />
+			<PlanningHeader title="Mon profil" />
 
 			<main className="profile">
 				<nav className="profile__nav">


### PR DESCRIPTION
📆 **Ajout du PlanningHeader pour le owner**

- Modification de _client/src/components/_molecules/PlanningHeader/PlanningHeader.tsx_ afin de conditionner l'affichage du button en fonction du rôle -> cela permet de ne pas avoir à l'ajouter à chaque instance du **PlanningHeader** dans les composants, on peut conditionner l'affichage du button uniquement s'il doit être false pour le trainer de cette manière
- Mise à jour des instances de **PlanningHeader** à travers les vues

_+ léger fix sur le TextInput de la description, il n'y avait pas de problème d'affichage juste une erreur de typage_