### PR TITLE
Ajout de la page des Mentions Légales

### DIFF
--- a/client/src/layouts/WelcomePage/Footer.tsx
+++ b/client/src/layouts/WelcomePage/Footer.tsx
@@ -19,10 +19,11 @@ function Footer() {
 						<Link to="/contact">Contact</Link>
 					</ul>
 					<ul className="welcomepage__footer--list">
-						<p className="welcomepage__footer--title">Mentions légales</p>
+						<p className="welcomepage__footer--title">Protection des données</p>
+						<Link to="/legal-notice">Mentions Légales</Link>
 						<Link to="/">Politique de confidentialité</Link>
-						<Link to="/offres">Conditions générales de vente</Link>
-						<Link to="/contact">Conditions générales d'utilisation</Link>
+						{/* <Link to="/offres">Conditions générales de vente</Link>
+						<Link to="/contact">Conditions générales d'utilisation</Link> */}
 					</ul>
 				</div>
 				<div className="welcomepage__footer--contact">

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -42,6 +42,7 @@ import ResetPassword from "./pages/Login/ResetPassword.tsx";
 // import Services from "@/pages/WelcomePage/Services.tsx";
 import FAQ from "@/pages/WelcomePage/FAQ.tsx";
 import UpdateDog from "./pages/Owner/Dogs/UpdateDog/UpdateDog.tsx";
+import LegalNotice from "./pages/WelcomePage/LegalNotice.tsx";
 
 // FIXME: delete
 import TestME from "./components/TestME.tsx";
@@ -63,6 +64,10 @@ const router = createBrowserRouter([
 					{
 						path: "FAQ",
 						element: <FAQ />,
+					},
+					{
+						path: "legal-notice",
+						element: <LegalNotice />,
 					},
 					{
 						path: "contact",

--- a/client/src/pages/WelcomePage/LegalNotice.scss
+++ b/client/src/pages/WelcomePage/LegalNotice.scss
@@ -1,0 +1,62 @@
+@use "@style" as *;
+
+.legalNotice__section {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 2rem;
+    text-align: justify;
+
+    .legalNotice__section--title {
+        display: flex;
+        align-items: baseline;
+        gap: 0.5rem;
+    
+        span {
+            font-size: 4rem;
+        
+        }
+    }
+    h2 {
+        margin-bottom: 4rem;
+        font-size: 4rem;
+        color: $primary-dark;
+    }
+    h3 {
+        margin: 1.5rem 0 0.75rem;
+        font-size: 1.3rem;
+        color: $primary-dark;
+    }
+    p {
+        margin-bottom: 1rem;
+        line-height: 1.6;
+    }
+    ul {
+        margin-bottom: 1rem;
+        padding-left: 1.5rem;
+        li {
+            margin-bottom: 0.5rem;
+            line-height: 1.6;
+        }
+    }
+    strong {
+        font-weight: 600;
+    }
+    a {
+        color: $blue-400;
+        font-style: italic;
+        text-decoration: underline;
+    }
+}
+
+@media screen and (max-width: $mobile) {
+    .legalNotice__section {
+        .legalNotice__section--title {
+            h2 {
+                font-size: 3rem;
+            }
+            span {
+                font-size: 3rem;
+            }
+        }
+    }
+}

--- a/client/src/pages/WelcomePage/LegalNotice.tsx
+++ b/client/src/pages/WelcomePage/LegalNotice.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import "./LegalNotice.scss";
+
+function LegalNotice() {
+	return (
+		<main className="legalNotice__section">
+			<div className="legalNotice__section--title">
+				<span>🐾</span>
+				<h2> Mentions légales</h2>
+			</div>
+			<p>
+				Le site <strong>PawPlanner</strong> est édité par la société PawPlanner,
+				SARL au capital de ronronnements infinis (et un peu de caféine), ayant
+				son siège social au :
+			</p>
+			<p>
+				<span>📍</span> 42 rue des Croquettes Infinies, 75000 Chat-Paris
+			</p>
+			<p>
+				Email de contact :{" "}
+				<strong>
+					<a href="mailto:contact@pawplanner.com">contact@pawplanner.com</a>
+				</strong>
+			</p>
+
+			<h3>1. Directeur de la publication</h3>
+			<p>
+				L'équipe PawPlanner, composée de{" "}
+				<a href="https://github.com/Dolpheus89" target="_blank">
+					Florian
+				</a>
+				,{" "}
+				<a href="https://github.com/FlorenceBuchelet" target="_blank">
+					Florence
+				</a>
+				,{" "}
+				<a href="https://github.com/Carcali" target="_blank">
+					Julien
+				</a>{" "}
+				et{" "}
+				<a href="https://github.com/Melprcllr" target="_blank">
+					Mélissa
+				</a>
+				, quatre humains passionnés par les animaux et l'organisation parfaite
+				(surtout quand elle inclut des chiens et des chats 🐕🐈).
+			</p>
+
+			<h3>2. Hébergement du site</h3>
+			<p>
+				Le site est hébergé par <strong>OVH</strong>
+			</p>
+			<p>2 rue Kellermann – 59100 Roubaix – France</p>
+			<p>
+				Site web :{" "}
+				<a href="https://www.ovh.com" target="_blank" rel="noopener noreferrer">
+					www.ovh.com
+				</a>
+			</p>
+
+			<h3>3. Propriété intellectuelle</h3>
+			<p>
+				Tous les contenus présents sur le site (textes, images, illustrations,
+				logo, etc.) sont la propriété exclusive de PawPlanner, sauf mention
+				contraire. Toute reproduction, représentation, modification ou
+				adaptation, totale ou partielle, est interdite sans autorisation écrite
+				préalable.
+			</p>
+
+			<h3>4. Responsabilité</h3>
+			<p>
+				L'équipe PawPlanner met tout en œuvre pour proposer un site fonctionnel
+				et agréable. Toutefois, elle ne saurait être tenue responsable en cas de
+				bugs, de contenus externes ou de disparition temporaire de croquettes.
+			</p>
+
+			<p>
+				<strong>
+					© {new Date().getFullYear()} PawPlanner - Tous droits réservés
+				</strong>
+			</p>
+		</main>
+	);
+}
+
+export default LegalNotice;


### PR DESCRIPTION
Ajout de la page des Mentions Légales 
Ajout du lien dans le footer

Objectifs : 

Identifier l’éditeur du site, informer sur la responsabilité et le cadre légal. En France (et dans l'UE) la loi (LCEN de 2004) impose à tout site (qui n'est pas personnel, commercial ou non) de publier ces informations (nom, adresse, contact, hébergeur...).
Elles permettent de tenir un responsable identifié en cas de problème (contenu illégal, litige, etc.).
Elles rassurent les utilisateurs sur la légitimité du site.
C'est obligatoire car PawPlanner va collecter des données, est public, et est édité par des personnes identifiables.