### PR TITLE
search filters in main search

### DIFF
--- a/.github/workflows/client-test.yml
+++ b/.github/workflows/client-test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   client:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node.js (client)
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: "18"
 
       - name: Install client dependencies
         working-directory: ./client

--- a/.github/workflows/server-test.yml
+++ b/.github/workflows/server-test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   server:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node.js (server)
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: "18"
 
       - name: Install server dependencies
         working-directory: ./server

--- a/client/.storybook/main.ts
+++ b/client/.storybook/main.ts
@@ -1,4 +1,5 @@
 import type { StorybookConfig } from "@storybook/react-vite";
+import path from "node:path";
 
 const config: StorybookConfig = {
   stories: ["../src/components/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
@@ -12,5 +13,16 @@ const config: StorybookConfig = {
     name: "@storybook/react-vite",
     options: {},
   },
+  viteFinal: (config) => {
+    return {
+      ...config,
+      resolve: {
+        alias: {
+          "@": path.resolve(__dirname, "../src"),
+          "@style": path.resolve(__dirname, "../src/styles/global.scss"),
+            },
+      },
+    };
+  }
 };
 export default config;

--- a/client/src/components/_atoms/FilterItem/FilterItem.scss
+++ b/client/src/components/_atoms/FilterItem/FilterItem.scss
@@ -1,0 +1,25 @@
+@use "@style" as *;
+
+$color : $beige-500;
+
+.filterItem {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    color: $color;
+    background-color: $beige-300;
+    border: 1px solid $color;
+    border-radius: $atoms-radius;
+    padding: 0.4rem 0.6rem;
+    margin: 0.15rem;
+    cursor: pointer;
+    &__close {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 1.1rem;
+        width: 1.1rem;
+        border-left: 1px solid $color;
+        padding-left: 0.4rem; 
+    }
+}

--- a/client/src/components/_atoms/FilterItem/FilterItem.stories.ts
+++ b/client/src/components/_atoms/FilterItem/FilterItem.stories.ts
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import FilterItem from "./FilterItem";
+
+const meta = {
+	title: "atoms/FilterItem",
+	component: FilterItem,
+	tags: ["autodocs"],
+	parameters: {
+		layout: "centered",
+	},
+	argTypes: {
+		filter: {
+			control: "text",
+		},
+		setFilters: {
+			action: "clicked",
+		},
+	},
+} satisfies Meta<typeof FilterItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		filter: "filter",
+		setFilters: () => {},
+	},
+};

--- a/client/src/components/_atoms/FilterItem/FilterItem.tsx
+++ b/client/src/components/_atoms/FilterItem/FilterItem.tsx
@@ -1,0 +1,21 @@
+import "./FilterItem.scss";
+
+interface FilterItemProps {
+	filter: string;
+	setFilters: React.Dispatch<React.SetStateAction<string[]>>;
+}
+
+function FilterItem({ filter, setFilters }: FilterItemProps) {
+	const handleClick = () => {
+		setFilters((prev) => prev.filter((f) => f !== filter));
+	};
+	return (
+		<>
+			<p onClick={handleClick} onKeyUp={handleClick} className="filterItem">
+				{filter}&nbsp;&nbsp;<span className="filterItem__close">x</span>
+			</p>
+		</>
+	);
+}
+
+export default FilterItem;

--- a/client/src/components/_atoms/SearchBar/SearchBar.scss
+++ b/client/src/components/_atoms/SearchBar/SearchBar.scss
@@ -9,6 +9,7 @@
     padding: 0.5rem;
     border-radius: $atoms-radius;
     font-size: $s;
+    width: 100%;
 
     & * {
         color: $font-light;

--- a/client/src/components/_atoms/SearchFilters/SearchFilters.scss
+++ b/client/src/components/_atoms/SearchFilters/SearchFilters.scss
@@ -1,0 +1,29 @@
+@use "@style" as *;
+
+.searchFilters {
+    border: none;
+    background-color: $beige-300;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem;
+    border-radius: $atoms-radius;
+    font-size: $s;
+    width: 30%;
+    & * {
+        border: none;
+    }
+    &__option {
+        background-color: $beige-300;
+        color: $blue-400;
+        border: 2px solid $blue-400;
+        
+    }
+}
+
+@media screen and (max-width: $mobile) {
+    .searchFilters {
+        width: 100%;
+    }
+}

--- a/client/src/components/_atoms/SearchFilters/SearchFilters.stories.ts
+++ b/client/src/components/_atoms/SearchFilters/SearchFilters.stories.ts
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import SearchFilters from "./SearchFilters";
+
+const meta = {
+	title: "atoms/SearchFilters",
+	component: SearchFilters,
+	tags: ["autodocs"],
+	parameters: {
+		layout: "centered",
+	},
+	argTypes: {
+		filterOptions: {
+			control: "object",
+		},
+		setFilters: {
+			table: {
+				disable: true,
+			},
+		},
+	},
+} satisfies Meta<typeof SearchFilters>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		filterOptions: ["Chien", "Propriétaire", "Evènement"],
+		setFilters: () => {},
+	},
+};

--- a/client/src/components/_atoms/SearchFilters/SearchFilters.tsx
+++ b/client/src/components/_atoms/SearchFilters/SearchFilters.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+import "./SearchFilters.scss";
+
+interface SearchFiltersProps {
+	setFilters: React.Dispatch<React.SetStateAction<string[]>>;
+	filterOptions: string[];
+}
+
+function SearchFilters({ setFilters, filterOptions }: SearchFiltersProps) {
+	const [selectedFilter, setSelectedFilter] = useState("");
+
+	const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+		const newFilter = e.target.value;
+		setSelectedFilter(newFilter);
+		setFilters((prev: string[]) =>
+			prev.includes(newFilter) ? prev : [...prev, newFilter],
+		);
+		setSelectedFilter("");
+	};
+
+	return (
+		<>
+			<select
+				className="searchFilters"
+				value={selectedFilter}
+				onChange={handleChange}
+			>
+				<option className="searchFilters__option" value="">
+					Filtrer par type de liste
+				</option>
+				{filterOptions.map((filter) => (
+					<option className="searchFilters__option" key={filter} value={filter}>
+						{filter}
+					</option>
+				))}
+			</select>
+		</>
+	);
+}
+
+export default SearchFilters;

--- a/client/src/components/_molecules/Search/Search.scss
+++ b/client/src/components/_molecules/Search/Search.scss
@@ -1,0 +1,16 @@
+@use "@style" as *;
+
+.search {
+    display: flex;
+    flex-direction: row;
+    gap: 1rem;
+    justify-content: center;
+    align-items: center;
+    margin-inline: 1rem;
+}
+
+@media screen and (max-width: $mobile) {
+    .search {
+        flex-direction: column;
+    }
+}

--- a/client/src/components/_molecules/Search/Search.stories.ts
+++ b/client/src/components/_molecules/Search/Search.stories.ts
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import Search from "./Search";
+
+const meta = {
+	title: "molecules/Search",
+	component: Search,
+	tags: ["autodocs"],
+	parameters: {
+		layout: "centered",
+	},
+	argTypes: {
+		filterOptions: {
+			control: "object",
+		},
+		setSearchTerm: {
+			table: {
+				disable: true,
+			},
+		},
+		setFilters: {
+			table: {
+				disable: true,
+			},
+		},
+	},
+} satisfies Meta<typeof Search>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		filterOptions: ["Chien", "Propriétaire", "Evènement"],
+		setSearchTerm: () => {},
+		setFilters: () => {},
+	},
+};

--- a/client/src/components/_molecules/Search/Search.tsx
+++ b/client/src/components/_molecules/Search/Search.tsx
@@ -1,0 +1,21 @@
+import SearchBar from "@/components/_atoms/SearchBar/SearchBar";
+import SearchFilters from "@/components/_atoms/SearchFilters/SearchFilters";
+
+import "./Search.scss";
+
+interface SearchProps {
+	setSearchTerm: (query: string) => void;
+	setFilters: React.Dispatch<React.SetStateAction<string[]>>;
+	filterOptions: string[];
+}
+
+function Search({ setSearchTerm, setFilters, filterOptions }: SearchProps) {
+	return (
+		<section className="search">
+			<SearchBar onSearch={setSearchTerm} />
+			<SearchFilters setFilters={setFilters} filterOptions={filterOptions} />
+		</section>
+	);
+}
+
+export default Search;

--- a/client/src/layouts/Dashboard/DashHeader.tsx
+++ b/client/src/layouts/Dashboard/DashHeader.tsx
@@ -28,16 +28,14 @@ export default function DashHeader() {
 				</button>
 				<span className="dashHeader__right-corner">
 					{isMobile && (
-						<>
-							<button
-								onClick={logout}
-								type="button"
-								className="dashSideBar__logout"
-								aria-label="Se déconnecter"
-							>
-								<Exit className="dashSideBar__icon" />
-							</button>
-						</>
+						<button
+							onClick={logout}
+							type="button"
+							className="dashSideBar__logout"
+							aria-label="Se déconnecter"
+						>
+							<Exit className="dashSideBar__icon dashHeader__icon" />
+						</button>
 					)}
 					<Link className="dashHeader__avatar" to="/my-profile">
 						<img

--- a/client/src/layouts/Dashboard/DashLayout.scss
+++ b/client/src/layouts/Dashboard/DashLayout.scss
@@ -141,6 +141,10 @@
     }
 }
 
+.dashHeader__icon {
+    width: 1.35rem;
+}
+
 // CONTENT DESKTOP
 .dashLayout__content {
     padding: $dashInlinePadding;

--- a/client/src/pages/Planning/Planning.scss
+++ b/client/src/pages/Planning/Planning.scss
@@ -521,7 +521,7 @@
     .fc .fc-prev-button,
     .fc .fc-next-button {
         background-color: $beige-300 !important;
-        color: $beige-400 !important;
+        color: $beige-500 !important;
         margin: 0 !important;
         border: 2px solid $beige-300;
 

--- a/client/src/pages/Trainer/Customers/CustomerList/CustomerList.scss
+++ b/client/src/pages/Trainer/Customers/CustomerList/CustomerList.scss
@@ -1,5 +1,10 @@
 @use "@style" as *;
 
-.searchbar {
-    margin-inline: 1rem;
+.filterItemsList {
+    padding-left: 0;
+	margin-left: 0;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
 }

--- a/client/src/pages/Trainer/Customers/CustomerList/CustomerList.tsx
+++ b/client/src/pages/Trainer/Customers/CustomerList/CustomerList.tsx
@@ -5,11 +5,14 @@ import { SEARCH_QUERY } from "@/graphQL/queries/search";
 import type { SearchIndex } from "@/types/Search";
 
 import PlanningHeader from "@/components/_molecules/PlanningHeader/PlanningHeader";
-import SearchBar from "@/components/_atoms/SearchBar/SearchBar";
+import Search from "@/components/_molecules/Search/Search";
 import SearchResultItem from "@/components/_atoms/SearchResultItem/SearchResultItem";
+import FilterItem from "@/components/_atoms/FilterItem/FilterItem";
 
 function CustomerList() {
 	const [searchTerm, setSearchTerm] = useState("");
+	const [filters, setFilters] = useState<string[]>([]);
+	const filterOptions = ["Éducateur", "Lieu", "Evènement", "Date", "Chien"];
 
 	const { data, loading, error } = useQuery(SEARCH_QUERY, {
 		variables: { query: searchTerm },
@@ -19,7 +22,16 @@ function CustomerList() {
 	return (
 		<>
 			<PlanningHeader title="Clients" />
-			<SearchBar onSearch={setSearchTerm} />
+			<Search
+				setSearchTerm={setSearchTerm}
+				setFilters={setFilters}
+				filterOptions={filterOptions}
+			/>
+			<ul className="filterItemsList">
+				{filters.map((filter) => (
+					<FilterItem key={filter} filter={filter} setFilters={setFilters} />
+				))}
+			</ul>
 
 			{loading && <p>Chargement...</p>}
 			{error && <p>Erreur : {error.message}</p>}


### PR DESCRIPTION
gestion des filtres en front, pas de lien avec le back pour le moment
On peut les selectionner et re-cliquer dessus pour les supprimer.

AVEC leurs storybooks (j'ai du maper les alias dans storybook/main.ts).


Une liste de filtre se trouve sur le composant qui gère la recherche, elle passe jusqu'au drop down menu qui permet de selectionner un filtre. Sur chaque filterItem on peut cliquer dessus pour à nouveau mettre cette liste à jour et enlever le filtre.

Les tests ne passaient plus car notre version de Ubuntu dans les workflows était obsolète.