### PR TITLE
(WIP) Ajout d'un champ à cocher d'acceptation des CGU par l'utilisateur

### DIFF
--- a/client/src/components/_atoms/Inputs/CheckboxInput/CheckboxInput.scss
+++ b/client/src/components/_atoms/Inputs/CheckboxInput/CheckboxInput.scss
@@ -1,0 +1,29 @@
+@use "@style" as *;
+
+.checkboxInput {
+    margin-bottom: 15px;
+
+    .checkbox-container {
+        display: flex;
+        align-items: center;
+
+        input[type="checkbox"] {
+            margin-right: 10px;
+            cursor: pointer;
+        }
+
+        label {
+            cursor: pointer;
+            font-size: 16px;
+
+            a {
+                color: $green-200;
+
+                &:hover {
+                    color: $green-400;
+                    text-decoration: none;
+                }
+            }
+        }
+    }
+}

--- a/client/src/components/_atoms/Inputs/CheckboxInput/CheckboxInput.tsx
+++ b/client/src/components/_atoms/Inputs/CheckboxInput/CheckboxInput.tsx
@@ -1,0 +1,108 @@
+import React, { useState, useRef, useImperativeHandle } from "react";
+import "./CheckboxInput.scss";
+import {
+	CHECKBOX_INPUT_CONFIG,
+	type CheckboxInputTypes,
+} from "./CheckboxInputConfig";
+
+interface CheckboxInputProps {
+	type: CheckboxInputTypes;
+	required?: boolean;
+	style?: "dark" | "light";
+	label?: React.ReactNode;
+	className?: string;
+	name?: string;
+	checked: boolean;
+	onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+/** CheckboxInput Component */
+const CheckboxInput = React.forwardRef<HTMLInputElement, CheckboxInputProps>(
+	(
+		{
+			type,
+			required = false,
+			style = "light",
+			label,
+			className = "",
+			name,
+			checked,
+			onChange,
+		},
+		ref,
+	) => {
+		const [error, setError] = useState<string>("");
+
+		const config = CHECKBOX_INPUT_CONFIG[type];
+		const mappedLabel = label || config.mappedLabel || "";
+		const fieldName = name || config.mappedName || type;
+		const validationRules = config.validationRules;
+
+		const inputRef = useRef<HTMLInputElement>(null);
+		useImperativeHandle(ref, () => inputRef.current as HTMLInputElement);
+
+		const inputId = `checkboxInput-${type}`;
+
+		const validateValue = () => {
+			let errorMessage = "";
+
+			if (required && validationRules && !checked) {
+				errorMessage = validationRules.message;
+			}
+
+			setError(errorMessage);
+			return errorMessage === "";
+		};
+
+		const handleBlur = () => {
+			validateValue();
+		};
+
+		const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+			if (onChange) {
+				onChange(e);
+			}
+
+			if (error) {
+				validateValue();
+			}
+		};
+
+		return (
+			<div
+				className={`checkboxInput ${className} checkboxInput__${style} ${error ? "has-error" : ""}`}
+				data-error={error}
+			>
+				<div className="checkbox-container">
+					<input
+						id={inputId}
+						name={fieldName}
+						ref={inputRef}
+						type="checkbox"
+						checked={checked}
+						required={required}
+						onChange={handleChange}
+						onBlur={handleBlur}
+						aria-invalid={!!error}
+						aria-describedby={error ? `${inputId}-error` : undefined}
+					/>
+					<label htmlFor={inputId}>
+						{mappedLabel}
+						{required ? " *" : ""}
+					</label>
+				</div>
+				{error && (
+					<div
+						id={`${inputId}-error`}
+						className="checkbox-error-message"
+						style={{ color: "red", fontSize: "14px", marginTop: "5px" }}
+					>
+						{error}
+					</div>
+				)}
+			</div>
+		);
+	},
+);
+
+export default CheckboxInput;

--- a/client/src/components/_atoms/Inputs/CheckboxInput/CheckboxInputConfig.ts
+++ b/client/src/components/_atoms/Inputs/CheckboxInput/CheckboxInputConfig.ts
@@ -1,0 +1,26 @@
+import validationRules from "@/helpers/readonly/validationRules";
+
+export type CheckboxInputTypes = "acceptTerms";
+
+export interface CheckboxInputConfigItem {
+	mappedLabel: React.ReactNode;
+	mappedName: string;
+	validationRules?: {
+		pattern: RegExp;
+		message: string;
+	};
+}
+
+export const CHECKBOX_INPUT_CONFIG: Record<
+	CheckboxInputTypes,
+	CheckboxInputConfigItem
+> = {
+	acceptTerms: {
+		mappedLabel: "J'accepte les Conditions Générales d'Utilisation (CGU)",
+		mappedName: "acceptTerms",
+		validationRules: {
+			pattern: validationRules.TERMS.pattern,
+			message: validationRules.TERMS.message,
+		},
+	},
+};

--- a/client/src/hooks/useForm.ts
+++ b/client/src/hooks/useForm.ts
@@ -15,7 +15,16 @@ export function useForm<T extends Record<string, unknown>>({
 
 	const handleChange = useCallback(
 		(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-			const { name, value } = e.target;
+			const target = e.target;
+			const name = target.name;
+
+			const isCheckbox =
+				target instanceof HTMLInputElement && target.type === "checkbox";
+
+			const value = isCheckbox
+				? (target as HTMLInputElement).checked
+				: target.value;
+
 			setValues((prev) => ({
 				...prev,
 				[name]: value,

--- a/client/src/pages/Registration/Registration.tsx
+++ b/client/src/pages/Registration/Registration.tsx
@@ -6,6 +6,7 @@ import { REGISTER_USER } from "@/graphQL/mutations/user";
 import Form from "@/components/_molecules/Form/Form";
 import "./Registration.scss";
 import TextInput from "@/components/_atoms/Inputs/TextInput/TextInput";
+import CheckboxInput from "@/components/_atoms/Inputs/CheckboxInput/CheckboxInput";
 import Button from "@/components/_atoms/Button/Button";
 import { toast } from "react-toastify";
 
@@ -20,6 +21,7 @@ interface RegistrationFormValues extends Record<string, unknown> {
 	telephone: string;
 	SIRET?: string;
 	company_name?: string;
+	acceptTerms: boolean;
 }
 
 function Registration() {
@@ -42,6 +44,7 @@ function Registration() {
 			telephone: "",
 			SIRET: "",
 			company_name: "",
+			acceptTerms: false,
 		},
 		onSubmit: async (formValues) => {
 			await handleSubmit(formValues);
@@ -51,12 +54,11 @@ function Registration() {
 	const handleSubmit = async (formValues: RegistrationFormValues) => {
 		setError(null);
 
-		// Vérification des mots de passe
+		// Check password
 		if (formValues.password !== formValues.confirmPassword) {
 			setError("Les mots de passe ne correspondent pas");
 			return;
 		}
-
 		try {
 			const userData = {
 				lastname: formValues.lastname,
@@ -228,6 +230,22 @@ function Registration() {
 										onChange={form.handleChange}
 										required
 									/>
+									<CheckboxInput
+										style="dark"
+										type="acceptTerms"
+										checked={form.values.acceptTerms as boolean}
+										onChange={form.handleChange}
+										required
+										label={
+											<>
+												J'accepte les{" "}
+												<Link to="/general-terms">
+													Conditions Générales d'Utilisation (CGU)
+												</Link>
+											</>
+										}
+									/>
+
 									{error && (
 										<div
 											className="error-message"

--- a/validationRules/validationRules.ts
+++ b/validationRules/validationRules.ts
@@ -36,6 +36,10 @@ const validationRules: ValidationRules = {
 		pattern: /^\d{14}$/,
 		message: "Le numéro SIRET doit contenir exactement 14 chiffres.",
 	},
+	TERMS: {
+		pattern: /^true$/,
+		message: " Vous devez accepter les Conditions Générales d'Utilisation (CGU) pour vous inscrire.",
+	},
 };
 
 export default validationRules;


### PR DESCRIPTION
Ajout d'un champ à cocher pour l'inscription de tout utilisateur, ce champ est obligatoire et l'absence de cette acceptation explicite (case cochée dans le formulaire) l'inscription ne peut aboutir.
Gestion du message d'erreur avec validationRules
Lien accessible dans le champ de case à cocher du formulaire permettant à l'utilisateur de lire les CGU si besoin.