### PR TITLE
create resolver for participation

### DIFF
--- a/client/src/graphQL/mutations/participation.ts
+++ b/client/src/graphQL/mutations/participation.ts
@@ -1,0 +1,21 @@
+import { gql } from "@apollo/client";
+
+export const CREATE_PARTICIPATION = gql`
+  mutation CreateParticipation($eventId: Float!, $dogId: Float!) {
+    createParticipation(eventId: $eventId, dogId: $dogId) {
+      id
+    }
+}
+`;
+
+export const DELETE_PARTICIPATION_BY_ID = gql`
+  mutation Mutation($participationId: Float!) {
+    deleteParticipationById(participationId: $participationId)
+  }
+`;
+
+export const DELETE_PARTICIPATION_BY_EVENT_AND_DOG_ID = gql`
+  mutation DeleteParticipationByEventAndDogId($eventId: Float!, $dogId: Float!) {
+    deleteParticipationByEventIdAndDogId(eventId: $eventId, dogId: $dogId)
+  }
+`;

--- a/client/src/graphQL/queries/participation.ts
+++ b/client/src/graphQL/queries/participation.ts
@@ -1,0 +1,31 @@
+import { gql } from "@apollo/client";
+
+import { EVENT_FRAGMENT, DOG_FRAGMENT } from "../fragments/fragments";
+
+export const GET_PARTICIPATION_BY_ID = gql`
+query GetParticipationById($participationId: Float!) {
+    getParticipationById(participationId: $participationId) {
+        id
+            event {
+                ...EventFragment
+            }
+            dog {
+                ...DogFragment
+            }
+    }
+}
+${EVENT_FRAGMENT}
+${DOG_FRAGMENT}
+`;
+
+export const GET_PARTICIPATIONS_BY_DOG_ID = gql`
+query GetParticipationByDogId($dogId: Float!) {
+    getParticipationByDogId(dogId: $dogId) {
+        id
+            event {
+                ...EventFragment
+            }
+    }
+}
+${EVENT_FRAGMENT}
+`;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -15,6 +15,7 @@ import { dataSource } from "./dataSource/dataSource";
 import { UserResolvers } from "./resolvers/UserResolvers";
 import { DogResolver } from "./resolvers/DogResolver";
 import { EventResolver } from "./resolvers/EventResolver";
+import { ParticipationResolver } from "./resolvers/ParticipationResolver";
 import { ServicesResolvers } from "./resolvers/ServicesResolvers";
 import { SearchResolvers } from "./resolvers/SearchResolvers";
 
@@ -27,6 +28,7 @@ export async function startServerApollo() {
 			UserResolvers,
 			DogResolver,
 			EventResolver,
+			ParticipationResolver,
 			ServicesResolvers,
 			SearchResolvers,
 		],

--- a/server/src/resolvers/ParticipationResolver.ts
+++ b/server/src/resolvers/ParticipationResolver.ts
@@ -1,0 +1,131 @@
+import { Arg, Mutation, Query, Resolver } from "type-graphql";
+import { dataSource } from "../dataSource/dataSource";
+import { Dog } from "../entities/Dog";
+import { Event } from "../entities/Event";
+import { Participation } from "../entities/Participation";
+
+const dogRepository = dataSource.getRepository(Dog);
+const eventRepository = dataSource.getRepository(Event);
+const participationRepository = dataSource.getRepository(Participation);
+
+@Resolver()
+export class ParticipationResolver {
+	@Query(() => Participation)
+	async getParticipationById(
+		@Arg("participationId") participationId: number,
+	): Promise<Participation | null> {
+		const participation = await participationRepository.findOne({
+			where: { id: participationId },
+			relations: ["event", "dog"],
+		});
+		return participation;
+	}
+
+	@Query(() => [Participation])
+	async getParticipationByDogId(
+		@Arg("dogId") dogId: number,
+	): Promise<Participation[] | []> {
+		const dog = await dogRepository.findOne({
+			where: { id: dogId },
+		});
+
+		if (!dog) {
+			throw new Error(`Dog with ID ${dogId} not found`);
+		}
+
+		const participation = await participationRepository.find({
+			where: { dog: dog },
+			relations: ["event", "dog"],
+		});
+
+		if (!participation) {
+			throw new Error(`participation of ${dog.name} not found`);
+		}
+
+		return participation || [];
+	}
+
+	@Mutation(() => Participation)
+	async createParticipation(
+		@Arg("dogId") dogId: number,
+		@Arg("eventId") eventId: number,
+	): Promise<Participation> {
+		const dog = await dogRepository.findOneBy({ id: dogId });
+		if (!dog) {
+			throw new Error(`Dog with ID ${dogId} not found`);
+		}
+
+		const event = await eventRepository.findOneBy({ id: eventId });
+		if (!event) {
+			throw new Error(`Event with ID ${eventId} not found`);
+		}
+
+		const existingParticipation = await participationRepository.findOne({
+			where: {
+				dog: { id: dogId },
+				event: { id: eventId },
+			},
+			relations: ["dog", "event"],
+		});
+
+		if (existingParticipation) {
+			throw new Error(
+				`Participation already exists for dog ID ${dogId} and event ID ${eventId}`,
+			);
+		}
+
+		const participation = new Participation(event, dog);
+		return await participationRepository.save(participation);
+	}
+
+	@Mutation(() => Boolean)
+	async deleteParticipationById(
+		@Arg("participationId") participationId: number,
+	): Promise<boolean> {
+		const participation = await participationRepository.findOne({
+			where: {
+				id: participationId,
+			},
+		});
+
+		if (!participation) {
+			throw new Error(`participation with ID ${participationId} not found`);
+		}
+
+		const result = await participationRepository.delete(participationId);
+		return result.affected ? result.affected > 0 : false;
+	}
+
+	@Mutation(() => Boolean)
+	async deleteParticipationByEventAndDogId(
+		@Arg("dogId") dogId: number,
+		@Arg("eventId") eventId: number,
+	): Promise<boolean> {
+		const dog = await dogRepository.findOneBy({ id: dogId });
+		if (!dog) {
+			throw new Error(`Dog with ID ${dogId} not found`);
+		}
+
+		const event = await eventRepository.findOneBy({ id: eventId });
+		if (!event) {
+			throw new Error(`Event with ID ${eventId} not found`);
+		}
+
+		const participation = await participationRepository.findOne({
+			where: {
+				dog: { id: dogId },
+				event: { id: eventId },
+			},
+			relations: ["dog", "event"],
+		});
+
+		if (!participation) {
+			throw new Error(
+				`participation with ID ${dogId} and ${eventId} not found`,
+			);
+		}
+
+		const result = await participationRepository.delete(participation);
+		return result.affected ? result.affected > 0 : false;
+	}
+}


### PR DESCRIPTION
Un tas de resolvers participation qui seront nécessaires à l'ajout ou la suppression d'un chien à un événement.

Mis en place dans le back et dans le dossier GraphQL du front, ils demandent à être utilisés.