### PR TITLE
Ajout d'une opacité baissée pour distinguer les événements passés

### DIFF
--- a/client/src/pages/Planning/Planning.scss
+++ b/client/src/pages/Planning/Planning.scss
@@ -5,6 +5,10 @@
     margin-top: 3vh;
     /* Under -> Allow to modify element per view */
 
+    .fc-event-past {
+        opacity: 0.7;
+    }
+
     /* dayGridMonth */
     .event-dayGridMonth {
         padding: 5px;


### PR DESCRIPTION
📆 **Planning : Distinction entre les événements du jour ou à venir et ceux passés :**

- Ajout dans **Planning.scss** d'une baisse d'opacité pour les événements passés
