### PR TITLE
Modification de la couleur du eyes de password-toggle

### DIFF
--- a/client/src/components/_atoms/Inputs/TextInput/TextInput.scss
+++ b/client/src/components/_atoms/Inputs/TextInput/TextInput.scss
@@ -68,7 +68,7 @@
 
         .password-toggle {  
             .eyes {
-                stroke: $primary-light;
+                stroke: $blue-100;
             }
         }
     }
@@ -89,7 +89,7 @@
 
         .password-toggle {  
             .eyes {
-                stroke: $primary-dark;
+                stroke: $blue-100;
             }
         }
     }


### PR DESCRIPTION
👁️ **password-toggle : Fix couleur quand mot de passe enregistré du eyes**

- Modification dans **client/src/components/_atoms/Inputs/TextInput/TextInput.scss** de la couleur de stroke de password-toggle -> eyes, le blue-100 crée suffisamment de contraste et n'est utilisé par aucune couleur native des navigateurs

https://trello.com/c/LtuRQJuT/315-fix-inscription-champ-auto-compl%C3%A9t%C3%A9-pour-le-mdp-loeil-nest-pas-visible