### PR TITLE
Ajout de reloadUser pour recharger les données de l'utilisateur

### DIFF
--- a/client/src/context/AuthContext.tsx
+++ b/client/src/context/AuthContext.tsx
@@ -22,6 +22,7 @@ interface TokenPayload {
 
 export interface AuthContextType extends AuthState {
 	updateAuth: (newAuthState: Partial<AuthState>) => void;
+	reloadUser: () => Promise<void>;
 }
 
 const initialAuthState: AuthState = {
@@ -35,6 +36,7 @@ const initialAuthState: AuthState = {
 export const AuthContext = createContext<AuthContextType>({
 	...initialAuthState,
 	updateAuth: () => {},
+	reloadUser: async () => {},
 });
 
 interface AuthProviderProps {
@@ -44,72 +46,72 @@ interface AuthProviderProps {
 export const AuthProvider = ({ children }: AuthProviderProps) => {
 	const [authState, setAuthState] = useState<AuthState>(initialAuthState);
 
-	useEffect(() => {
-		const loadUserData = async () => {
-			const token = localStorage.getItem("authToken");
+	const loadUserData = async () => {
+		const token = localStorage.getItem("authToken");
 
-			if (!token) {
+		if (!token) {
+			setAuthState((prev) => ({
+				...prev,
+				isAuthenticated: false,
+				isLoading: false,
+			}));
+			return;
+		}
+
+		try {
+			setAuthState((prev) => ({ ...prev, isLoading: true }));
+			const decoded = jwtDecode<TokenPayload>(token);
+			const currentTime = Date.now() / 1000;
+
+			if (decoded.exp < currentTime) {
+				localStorage.removeItem("authToken");
 				setAuthState((prev) => ({
 					...prev,
-					isAuthenticated: false,
 					isLoading: false,
+					isAuthenticated: false,
 				}));
 				return;
 			}
 
-			try {
-				setAuthState((prev) => ({ ...prev, isLoading: true }));
-				const decoded = jwtDecode<TokenPayload>(token);
-				const currentTime = Date.now() / 1000;
+			const isTrainer = decoded.role === "trainer";
 
-				if (decoded.exp < currentTime) {
-					localStorage.removeItem("authToken");
-					setAuthState((prev) => ({
-						...prev,
-						isLoading: false,
-						isAuthenticated: false,
-					}));
-					return;
-				}
+			const { data } = await client.query({
+				query: ME,
+				variables: {
+					token,
+					isTrainer,
+				},
+				fetchPolicy: "no-cache",
+			});
 
-				const isTrainer = decoded.role === "trainer";
-
-				const { data } = await client.query({
-					query: ME,
-					variables: {
-						token,
-						isTrainer,
-					},
-					fetchPolicy: "no-cache",
+			if (data.me) {
+				setAuthState({
+					user: data.me,
+					role: decoded.role as "owner" | "trainer",
+					isAuthenticated: true,
+					isLoading: false,
+					error: null,
 				});
-
-				if (data.me) {
-					setAuthState({
-						user: data.me,
-						role: decoded.role as "owner" | "trainer",
-						isAuthenticated: true,
-						isLoading: false,
-						error: null,
-					});
-				} else {
-					localStorage.removeItem("authToken");
-					setAuthState({
-						...initialAuthState,
-						isLoading: false,
-					});
-				}
-			} catch (error) {
+			} else {
 				localStorage.removeItem("authToken");
 				setAuthState({
 					...initialAuthState,
 					isLoading: false,
-					error: error instanceof ApolloError ? error : null,
 				});
 			}
-		};
+		} catch (error) {
+			localStorage.removeItem("authToken");
+			setAuthState({
+				...initialAuthState,
+				isLoading: false,
+				error: error instanceof ApolloError ? error : null,
+			});
+		}
+	};
 
-		loadUserData();
-	}, []);
+	const reloadUser = async () => {
+		await loadUserData();
+	};
 
 	const updateAuth = (newAuthState: Partial<AuthState>) => {
 		setAuthState((prev) => {
@@ -129,6 +131,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
 	const value = {
 		...authState,
 		updateAuth,
+		reloadUser,
 	};
 
 	return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/client/src/pages/Owner/Dog/DogForm/DogForm.tsx
+++ b/client/src/pages/Owner/Dog/DogForm/DogForm.tsx
@@ -35,7 +35,7 @@ export default function DogForm({
 	const [tempFile, setTempFile] = useState<File | null>(null);
 	const [previewUrl, setPreviewUrl] = useState<string | null>(null);
 
-	const { user } = useUser();
+	const { user, reloadUser } = useUser();
 	const navigate = useNavigate();
 
 	const form = useForm<DogFormValues>({
@@ -118,6 +118,8 @@ export default function DogForm({
 			await selectedQuery({
 				variables,
 			});
+
+			await reloadUser();
 
 			const message =
 				mode === "create"

--- a/client/src/pages/Profile/Profile.tsx
+++ b/client/src/pages/Profile/Profile.tsx
@@ -29,7 +29,7 @@ export interface ProfileFormValues extends Record<string, unknown> {
 }
 
 function Profile() {
-	const { role, user } = useUser();
+	const { role, user, reloadUser } = useUser();
 	const [view, setView] = useState<ViewType>("profile");
 
 	const [previewUrl, setPreviewUrl] = useState<string | null>(null);
@@ -96,13 +96,15 @@ function Profile() {
 					isTrainer: isTrainer,
 				},
 			});
-			if (response.data.UpdateUser.message === "User updated successfully") {
+
+			const message = response.data?.UpdateUser?.message;
+
+			if (message === "User updated successfully") {
 				toast.success("Profil sauvegardé avec succès !");
-			} else if (response.data.UpdateUser.message === "User not found") {
+				await reloadUser();
+			} else if (message === "User not found") {
 				toast.error("Utilisateur non trouvé.");
-			} else if (
-				response.data.UpdateUser.message === "There was no field to update"
-			) {
+			} else if (message === "There was no field to update") {
 				toast.warning("Aucun champ à mettre à jour.");
 			} else {
 				toast.error("Erreur lors de la mise à jour du profil.");


### PR DESCRIPTION
👨🏻 **Ajout de reloadUser**

- Ajout de **reloadUser** dans le _AuthContext_ afin de recharger les données de l'utilisateur
- Assure que l’état du contexte est toujours synchronisé avec la réalité du backend et du token JWT

https://trello.com/c/BkbwF0Ap/319-refetch-sur-les-profils-trainer-owner-dogs